### PR TITLE
Fixed sharing of blog posts

### DIFF
--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -47,7 +47,7 @@ const BlogPost = ({ post, morePosts }) => {
       title={post?.fields.title}
       description={post?.fields.subTitle}
       ogImage={post?.fields.coverImage.fields.file.url}
-      url={`https://portfolio-git-dev-pupriku.vercel.app/${post?.fields.slug}`}
+      url={`https://portfolio-git-dev-pupriku.vercel.app/blog/${post?.fields.slug}`}
       style={{ marginTop: "5em" }}
     >
       <PostHeader
@@ -73,7 +73,7 @@ const BlogPost = ({ post, morePosts }) => {
             >
               - Share -
             </Typography>
-            <ShareButton url={`https://portfolio-git-dev-pupriku.vercel.app/${post?.fields.slug}`} title={post?.fields.title} />
+            <ShareButton url={`https://portfolio-git-dev-pupriku.vercel.app/blog/${post?.fields.slug}`} title={post?.fields.title} />
           </Grid>
         </Grid>
         <Typography

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -47,7 +47,7 @@ const BlogPost = ({ post, morePosts }) => {
       title={post?.fields.title}
       description={post?.fields.subTitle}
       ogImage={post?.fields.coverImage.fields.file.url}
-      url={`localhost:3000/blog/${post?.fields.slug}`}
+      url={`https://portfolio-git-dev-pupriku.vercel.app/${post?.fields.slug}`}
       style={{ marginTop: "5em" }}
     >
       <PostHeader
@@ -73,7 +73,7 @@ const BlogPost = ({ post, morePosts }) => {
             >
               - Share -
             </Typography>
-            <ShareButton url={`localhost:3000/blog/${post?.fields.slug}`} title={post?.fields.title} />
+            <ShareButton url={`https://portfolio-git-dev-pupriku.vercel.app/${post?.fields.slug}`} title={post?.fields.title} />
           </Grid>
         </Grid>
         <Typography

--- a/src/ui/post/ShareButton.js
+++ b/src/ui/post/ShareButton.js
@@ -10,10 +10,6 @@ import {
   EmailIcon,
   LinkedinShareButton,
   LinkedinIcon,
-  TumblrShareButton,
-  TumblrIcon,
-  FacebookMessengerShareButton,
-  FacebookMessengerIcon,
 } from "react-share";
 
 const ShareButton = ({ url, title }) => (
@@ -47,12 +43,6 @@ const ShareButton = ({ url, title }) => (
     >
       <TelegramIcon size="32px" round />
     </TelegramShareButton>
-    <FacebookMessengerShareButton
-      url={url}
-      style={{ marginLeft: `15px`, outline: "none" }}
-    >
-      <FacebookMessengerIcon size="32px" round />
-    </FacebookMessengerShareButton>
     <EmailShareButton
       url={url}
       style={{ marginLeft: `15px`, outline: "none" }}


### PR DESCRIPTION
Made a mistake by deleting /blog/ from the URL for posts. This caused issues with sharing posts via social media. I also removed the Facebook messenger share button.